### PR TITLE
feat: redesign dashboard layout

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,6 @@
-import { Box, Container, Paper, Stack, Typography, Button } from "@mui/material";
 import { redirect } from "next/navigation";
 
-import { logout } from "@/app/actions/auth";
+import DashboardView from "@/components/dashboard/DashboardView";
 import { getCurrentUser } from "@/lib/auth";
 
 export default async function DashboardPage() {
@@ -11,45 +10,5 @@ export default async function DashboardPage() {
     redirect("/");
   }
 
-  return (
-    <Box
-      component="main"
-      sx={{
-        minHeight: "100vh",
-        // backgroundColor: (theme) => theme.palette.grey[100],
-        py: { xs: 6, md: 10 },
-        px: { xs: 2, md: 4 },
-      }}
-    >
-      <Container maxWidth="md">
-        <Paper
-          elevation={4}
-          sx={{
-            p: { xs: 4, md: 6 },
-            borderRadius: 4,
-          }}
-        >
-          <Stack spacing={3}>
-            <Typography component="h1" variant="h4" fontWeight={700}>
-              ยินดีต้อนรับกลับ {user.name ?? user.email}
-            </Typography>
-            <Typography color="text.secondary" variant="body1">
-              คุณสามารถเริ่มจัดการลูกค้า โอกาส และติดตามงานได้จากส่วนนี้ของระบบ CRM.
-            </Typography>
-
-            <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems={{ xs: "stretch", sm: "center" }}>
-              <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
-                หากต้องการออกจากระบบ ให้กดปุ่มด้านล่างเมื่อใช้งานเสร็จสิ้นเพื่อความปลอดภัยของข้อมูล
-              </Typography>
-              <form action={logout}>
-                <Button type="submit" variant="outlined" color="primary">
-                  ออกจากระบบ
-                </Button>
-              </form>
-            </Stack>
-          </Stack>
-        </Paper>
-      </Container>
-    </Box>
-  );
+  return <DashboardView userName={user.name ?? user.email} />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,11 @@ import { CacheProvider } from "@emotion/react";
 import { ThemeProvider, CssBaseline } from "@mui/material";
 import createEmotionCache from "../src/createEmotionCache";
 import theme from "../src/theme";
+import "@fontsource/prompt/400.css";
+import "@fontsource/prompt/500.css";
+import "@fontsource/prompt/600.css";
+import "@fontsource/prompt/700.css";
+import "@fontsource/prompt/800.css";
 
 const clientSideEmotionCache = createEmotionCache();
 

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -2,14 +2,12 @@
 
 import { useActionState } from "react";
 import Image from "next/image";
-import { Prompt } from "next/font/google";
 import {
   Alert,
   Box,
   Button,
   Checkbox,
   FormControlLabel,
-  Link,
   Stack,
   TextField,
   Typography,
@@ -17,11 +15,7 @@ import {
 
 import { login, type LoginState } from "@/app/actions/auth";
 
-// โหลดฟอนต์ Prompt
-const prompt = Prompt({
-  weight: ["400", "500", "700"], // เลือกน้ำหนักฟอนต์
-  subsets: ["thai", "latin"], // ให้รองรับภาษาไทย
-});
+const promptFontFamily = '"Prompt", "Roboto", "Helvetica", "Arial", sans-serif';
 
 const initialState: LoginState = {};
 
@@ -29,12 +23,7 @@ export default function LoginForm() {
   const [state, formAction, isPending] = useActionState(login, initialState);
 
   return (
-    <Box
-      component="form"
-      action={formAction}
-      noValidate
-      sx={{ fontFamily: prompt.style.fontFamily }}
-    >
+    <Box component="form" action={formAction} noValidate sx={{ fontFamily: promptFontFamily }}>
       <Stack spacing={2}>
         <Stack spacing={2} alignItems="center" textAlign="center">
           <Box
@@ -61,17 +50,13 @@ export default function LoginForm() {
               component="p"
               variant="h4"
               fontWeight={800}
-              sx={{
-                textTransform: "uppercase",
-                letterSpacing: 2.4,
-                fontFamily: prompt.style.fontFamily, // 👈 บังคับใช้ Prompt
-              }}
+              sx={{ textTransform: "uppercase", letterSpacing: 2.4, fontFamily: promptFontFamily }}
             >
               ระบบ{" "}
               <Box
                 component="span"
                 color="#c62828"
-                sx={{ fontFamily: prompt.style.fontFamily }}
+                sx={{ fontFamily: promptFontFamily }}
               >
                 CS ONE
               </Box>
@@ -90,12 +75,7 @@ export default function LoginForm() {
           <Typography
             variant="h5"
             fontWeight={600}
-            sx={{
-              letterSpacing: 1.5,
-              fontFamily: prompt.style.fontFamily,
-              position: "relative",
-              top: 12,
-            }}
+            sx={{ letterSpacing: 1.5, fontFamily: promptFontFamily, position: "relative", top: 12 }}
           >
             เข้าสู่ระบบ
           </Typography>
@@ -115,7 +95,7 @@ export default function LoginForm() {
           InputLabelProps={{
             sx: {
               fontSize: { xs: "0.8rem", md: "0.95rem" },
-              fontFamily: prompt.style.fontFamily,
+              fontFamily: promptFontFamily,
             },
           }}
           sx={{
@@ -126,7 +106,7 @@ export default function LoginForm() {
                 paddingLeft: "14px",
                 paddingY: { xs: "6px", md: "10px" },
                 fontSize: { xs: "0.85rem", md: "1rem" },
-                fontFamily: prompt.style.fontFamily,
+                fontFamily: promptFontFamily,
               },
             },
             top: 12,
@@ -144,7 +124,7 @@ export default function LoginForm() {
           InputLabelProps={{
             sx: {
               fontSize: { xs: "0.8rem", md: "0.95rem" }, // ⬅ label
-              fontFamily: prompt.style.fontFamily,
+              fontFamily: promptFontFamily,
             },
           }}
           sx={{
@@ -155,7 +135,7 @@ export default function LoginForm() {
                 paddingLeft: "14px",
                 paddingY: { xs: "6px", md: "10px" },
                 fontSize: { xs: "0.85rem", md: "1rem" }, // ⬅ text ในช่อง
-                fontFamily: prompt.style.fontFamily,
+                fontFamily: promptFontFamily,
               },
             },
             top: 12,
@@ -199,7 +179,7 @@ export default function LoginForm() {
               backgroundColor: "#424242",
               boxShadow: "0 10px 18px rgba(0,0,0,0.2)",
             },
-            fontFamily: prompt.style.fontFamily,
+            fontFamily: promptFontFamily,
             fontSize: { xs: "0.9rem", md: "1rem" }, // ⬅ ขนาดฟอนต์เล็กลงบนมือถือ
           }}
         >

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -1,0 +1,583 @@
+"use client";
+
+import Image from "next/image";
+import {
+  Avatar,
+  Badge,
+  Box,
+  Chip,
+  Divider,
+  IconButton,
+  InputAdornment,
+  LinearProgress,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { BarChart } from "@mui/x-charts";
+import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
+import CampaignRoundedIcon from "@mui/icons-material/CampaignRounded";
+import ChevronRightRoundedIcon from "@mui/icons-material/ChevronRightRounded";
+import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
+import HomeRoundedIcon from "@mui/icons-material/HomeRounded";
+import NotificationsNoneRoundedIcon from "@mui/icons-material/NotificationsNoneRounded";
+import PeopleAltRoundedIcon from "@mui/icons-material/PeopleAltRounded";
+import SearchRoundedIcon from "@mui/icons-material/SearchRounded";
+import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
+import ShoppingCartRoundedIcon from "@mui/icons-material/ShoppingCartRounded";
+import TrendingUpRoundedIcon from "@mui/icons-material/TrendingUpRounded";
+import WorkspacePremiumRoundedIcon from "@mui/icons-material/WorkspacePremiumRounded";
+
+type DashboardViewProps = {
+  userName: string;
+};
+
+const sidebarItems = [
+  {
+    label: "รายงานภาพรวม",
+    icon: <HomeRoundedIcon fontSize="medium" />,
+    active: true,
+  },
+  { label: "ฐานข้อมูลลูกค้า", icon: <PeopleAltRoundedIcon fontSize="medium" /> },
+  { label: "โอกาสทางการขาย", icon: <TrendingUpRoundedIcon fontSize="medium" /> },
+  { label: "คำสั่งซื้อ", icon: <ShoppingCartRoundedIcon fontSize="medium" /> },
+  { label: "ติดตามผล", icon: <AssessmentRoundedIcon fontSize="medium" /> },
+  { label: "โปรโมชั่น", icon: <CampaignRoundedIcon fontSize="medium" /> },
+];
+
+const summaryCards = [
+  {
+    title: "ยอดขายเดือนนี้",
+    amount: "฿1,250,000",
+    subLabel: "เพิ่มขึ้น 18.5%",
+    highlight: "+195,000",
+    highlightColor: "#2e7d32",
+    avatarBg: "rgba(198,40,40,0.08)",
+    iconColor: "#c62828",
+    icon: <TrendingUpRoundedIcon />,
+  },
+  {
+    title: "ยอดขายสะสมปีนี้",
+    amount: "฿8,950,000",
+    subLabel: "ใกล้ถึงเป้า 12M",
+    highlight: "-250,000",
+    highlightColor: "#c62828",
+    avatarBg: "rgba(21,101,192,0.12)",
+    iconColor: "#1565c0",
+    icon: <AssessmentRoundedIcon />,
+  },
+  {
+    title: "ยอดขายสะสมเดือนนี้",
+    amount: "฿1,500,000",
+    subLabel: "ตรงตามแผน",
+    highlight: "±0",
+    highlightColor: "#757575",
+    avatarBg: "rgba(67,160,71,0.12)",
+    iconColor: "#2e7d32",
+    icon: <ShoppingCartRoundedIcon />,
+  },
+  {
+    title: "ยอดขายสะสมทั้งปี",
+    amount: "฿10,750,000",
+    subLabel: "เหลืออีก 1.25M",
+    highlight: "+650,000",
+    highlightColor: "#2e7d32",
+    avatarBg: "rgba(255,179,0,0.15)",
+    iconColor: "#ff8f00",
+    icon: <WorkspacePremiumRoundedIcon />,
+  },
+];
+
+const revenueSeries = [
+  { month: "ม.ค.", target: 120, sales: 110, invoice: 100 },
+  { month: "ก.พ.", target: 115, sales: 105, invoice: 97 },
+  { month: "มี.ค.", target: 130, sales: 125, invoice: 120 },
+  { month: "เม.ย.", target: 140, sales: 132, invoice: 126 },
+  { month: "พ.ค.", target: 150, sales: 147, invoice: 138 },
+  { month: "มิ.ย.", target: 160, sales: 155, invoice: 148 },
+];
+
+const topCustomers = [
+  {
+    label: "กลุ่ม A",
+    value: "฿450k",
+    rate: 78,
+    color: "#1976d2",
+  },
+  {
+    label: "กลุ่ม B",
+    value: "฿320k",
+    rate: 64,
+    color: "#43a047",
+  },
+  {
+    label: "กลุ่ม C",
+    value: "฿280k",
+    rate: 58,
+    color: "#fb8c00",
+  },
+];
+
+const activities = [
+  { label: "ติดตามลูกค้าใหม่", value: 75, color: "#1976d2" },
+  { label: "โอกาสที่ต้องเร่งด่วน", value: 50, color: "#e53935" },
+  { label: "ใบเสนอราคาที่ค้างอยู่", value: 30, color: "#fb8c00" },
+];
+
+type Promotion = {
+  title: string;
+  description: string;
+  chipLabel: string;
+  color: string;
+  chipColor: "default" | "primary" | "secondary" | "success" | "error" | "info" | "warning";
+};
+
+const promotions: Promotion[] = [
+  {
+    title: "โปรโมชันตรุษจีน",
+    description: "ส่วนลดสูงสุด 15% สำหรับสินค้าใหม่",
+    chipLabel: "กำลังทำ",
+    color: "#fff3e0",
+    chipColor: "warning",
+  },
+  {
+    title: "โครงการ Smart Farm",
+    description: "แพ็กเกจระบบรดน้ำอัจฉริยะ ลด 20%",
+    chipLabel: "สำเร็จ 80%",
+    color: "#e3f2fd",
+    chipColor: "primary",
+  },
+];
+
+export default function DashboardView({ userName }: DashboardViewProps) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        minHeight: "100vh",
+        bgcolor: "#f4f6f8",
+      }}
+    >
+      <Box
+        component="aside"
+        sx={{
+          width: { xs: 88, lg: 256 },
+          bgcolor: "#c62828",
+          color: "#fff",
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+          py: { xs: 4, lg: 6 },
+          px: { xs: 2, lg: 3 },
+        }}
+      >
+        <Stack direction={{ xs: "column", lg: "row" }} alignItems="center" spacing={2}>
+          <Box
+            sx={{
+              width: 64,
+              height: 64,
+              borderRadius: 2,
+              overflow: "hidden",
+              position: "relative",
+              boxShadow: "0 8px 20px rgba(0,0,0,0.3)",
+            }}
+          >
+            <Image src="/images/logo.jpg" alt="CS One" fill sizes="64px" style={{ objectFit: "cover" }} />
+          </Box>
+          <Stack spacing={0.5} display={{ xs: "none", lg: "flex" }}>
+            <Typography variant="h6" fontWeight={700} letterSpacing={1.2}>
+              อย่างไม่ยาก
+            </Typography>
+            <Typography variant="body2" sx={{ opacity: 0.85 }}>
+              Smart Crop Smart Solutions
+            </Typography>
+          </Stack>
+        </Stack>
+
+        <List sx={{ flex: 1, display: "flex", flexDirection: "column", gap: 1 }}>
+          {sidebarItems.map((item) => (
+            <ListItemButton
+              key={item.label}
+              selected={item.active}
+              sx={{
+                borderRadius: 2,
+                bgcolor: item.active ? "rgba(255,255,255,0.18)" : "transparent",
+                color: "inherit",
+                "&.Mui-selected": {
+                  bgcolor: "rgba(255,255,255,0.22)",
+                  "&:hover": {
+                    bgcolor: "rgba(255,255,255,0.25)",
+                  },
+                },
+                "&:hover": {
+                  bgcolor: "rgba(255,255,255,0.12)",
+                },
+              }}
+            >
+              <ListItemIcon sx={{ color: "inherit", minWidth: 40 }}>{item.icon}</ListItemIcon>
+              <ListItemText
+                primary={item.label}
+                primaryTypographyProps={{
+                  fontWeight: item.active ? 700 : 500,
+                  fontSize: "0.95rem",
+                }}
+                sx={{ display: { xs: "none", lg: "block" } }}
+              />
+            </ListItemButton>
+          ))}
+        </List>
+
+        <Stack spacing={2} display={{ xs: "none", lg: "flex" }}>
+          <Typography variant="subtitle2" sx={{ opacity: 0.8 }}>
+            ทีมยอดขายประจำเดือน
+          </Typography>
+          <Stack direction="row" alignItems="center" spacing={1.5}>
+            <Avatar src="/images/man-avatar.png" alt="Team lead" sx={{ width: 40, height: 40 }} />
+            <Box>
+              <Typography variant="subtitle1" fontWeight={700}>
+                วรเมธ ศรีชัย
+              </Typography>
+              <Typography variant="caption" sx={{ opacity: 0.75 }}>
+                ผู้จัดการฝ่ายขาย
+              </Typography>
+            </Box>
+          </Stack>
+        </Stack>
+      </Box>
+
+      <Box sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <Box
+          component="header"
+          sx={{
+            px: { xs: 3, lg: 5 },
+            py: { xs: 3, lg: 4 },
+            borderBottom: "1px solid rgba(0,0,0,0.06)",
+            bgcolor: "#fff",
+          }}
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            spacing={3}
+            justifyContent="space-between"
+            flexWrap="wrap"
+            rowGap={2}
+          >
+            <Stack spacing={0.5}>
+              <Typography variant="h5" fontWeight={700} color="text.primary">
+                ภาพรวมการขาย
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                ยอดขายล่าสุดและกิจกรรมประจำวัน
+              </Typography>
+            </Stack>
+
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={2}
+              flexWrap="wrap"
+              justifyContent={{ xs: "flex-start", md: "flex-end" }}
+              rowGap={1.5}
+            >
+              <TextField
+                size="small"
+                placeholder="ค้นหา..."
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchRoundedIcon color="action" />
+                    </InputAdornment>
+                  ),
+                }}
+                sx={{
+                  minWidth: { xs: 140, sm: 220 },
+                  "& .MuiOutlinedInput-root": {
+                    borderRadius: 3,
+                    bgcolor: "rgba(0,0,0,0.02)",
+                  },
+                }}
+              />
+              <IconButton
+                color="default"
+                sx={{
+                  bgcolor: "rgba(198,40,40,0.08)",
+                  color: "#c62828",
+                  "&:hover": { bgcolor: "rgba(198,40,40,0.16)" },
+                }}
+              >
+                <Badge color="error" badgeContent={3} overlap="circular">
+                  <NotificationsNoneRoundedIcon />
+                </Badge>
+              </IconButton>
+              <IconButton
+                color="default"
+                sx={{
+                  bgcolor: "rgba(0,0,0,0.04)",
+                  "&:hover": { bgcolor: "rgba(0,0,0,0.08)" },
+                }}
+              >
+                <SettingsRoundedIcon />
+              </IconButton>
+              <IconButton
+                color="default"
+                sx={{
+                  bgcolor: "rgba(0,0,0,0.04)",
+                  "&:hover": { bgcolor: "rgba(0,0,0,0.08)" },
+                }}
+              >
+                <HelpOutlineRoundedIcon />
+              </IconButton>
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <Avatar src="/images/man-avatar.png" alt={userName} sx={{ width: 44, height: 44 }} />
+                <Box display={{ xs: "none", sm: "block" }}>
+                  <Typography variant="subtitle1" fontWeight={700}>
+                    {userName}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    ผู้ดูแลระบบ
+                  </Typography>
+                </Box>
+                <ChevronRightRoundedIcon color="action" />
+              </Stack>
+            </Stack>
+          </Stack>
+        </Box>
+
+        <Box component="main" sx={{ flex: 1, px: { xs: 3, lg: 5 }, py: { xs: 3, lg: 4 } }}>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 3,
+              gridTemplateColumns: {
+                xs: "1fr",
+                md: "repeat(2, minmax(0, 1fr))",
+                xl: "repeat(4, minmax(0, 1fr))",
+              },
+            }}
+          >
+            {summaryCards.map((card) => (
+              <Paper
+                key={card.title}
+                elevation={0}
+                sx={{
+                  borderRadius: 4,
+                  p: 3,
+                  bgcolor: "#fff",
+                  boxShadow: "0 12px 30px rgba(0,0,0,0.05)",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 1,
+                  height: "100%",
+                }}
+              >
+                <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                  <Box>
+                    <Typography variant="subtitle2" color="text.secondary">
+                      {card.title}
+                    </Typography>
+                    <Typography variant="h5" fontWeight={800} sx={{ mt: 0.5 }}>
+                      {card.amount}
+                    </Typography>
+                  </Box>
+                  <Avatar
+                    sx={{
+                      bgcolor: card.avatarBg,
+                      color: card.iconColor,
+                      width: 46,
+                      height: 46,
+                    }}
+                  >
+                    {card.icon}
+                  </Avatar>
+                </Stack>
+                <Typography variant="body2" color="text.secondary">
+                  {card.subLabel}
+                </Typography>
+                <Typography variant="subtitle2" sx={{ color: card.highlightColor, fontWeight: 700 }}>
+                  {card.highlight}
+                </Typography>
+              </Paper>
+            ))}
+          </Box>
+
+          <Box
+            sx={{
+              mt: 1,
+              display: "grid",
+              gap: 3,
+              gridTemplateColumns: { xs: "1fr", lg: "minmax(0, 2fr) minmax(0, 1fr)" },
+              alignItems: "stretch",
+            }}
+          >
+            <Paper
+              elevation={0}
+              sx={{
+                borderRadius: 4,
+                p: { xs: 3, md: 4 },
+                boxShadow: "0 12px 30px rgba(0,0,0,0.05)",
+                bgcolor: "#fff",
+              }}
+            >
+              <Stack direction={{ xs: "column", sm: "row" }} justifyContent="space-between" alignItems={{ xs: "flex-start", sm: "center" }} spacing={2}>
+                <Box>
+                  <Typography variant="h6" fontWeight={700}>
+                      ยอดขายจากลูกค้า
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      เปรียบเทียบเป้าหมายและยอดขายจริงในปี 2024
+                    </Typography>
+                  </Box>
+                  <Chip label="รายงานประจำเดือน" color="error" variant="outlined" sx={{ borderRadius: 999, fontWeight: 600 }} />
+                </Stack>
+
+                <Box sx={{ mt: 4 }}>
+                  <BarChart
+                    dataset={revenueSeries}
+                    height={300}
+                    xAxis={[{ dataKey: "month", scaleType: "band" }]}
+                    series={[
+                      { dataKey: "target", label: "Target", color: "#ffd54f" },
+                      { dataKey: "sales", label: "Sales Rate", color: "#ef5350" },
+                      { dataKey: "invoice", label: "Invoice", color: "#42a5f5" },
+                    ]}
+                    margin={{ top: 10, bottom: 20, left: 50, right: 10 }}
+                  />
+                </Box>
+
+                <Divider sx={{ my: 3 }} />
+
+                <Stack direction={{ xs: "column", md: "row" }} spacing={3}>
+                  {topCustomers.map((customer) => (
+                    <Box key={customer.label} sx={{ flex: 1 }}>
+                      <Typography variant="subtitle2" color="text.secondary">
+                        {customer.label}
+                      </Typography>
+                      <Typography variant="h6" fontWeight={700} sx={{ mt: 0.5 }}>
+                        {customer.value}
+                      </Typography>
+                      <LinearProgress
+                        variant="determinate"
+                        value={customer.rate}
+                        sx={{
+                          mt: 1.5,
+                          height: 10,
+                          borderRadius: 999,
+                          bgcolor: "rgba(0,0,0,0.06)",
+                          "& .MuiLinearProgress-bar": {
+                            borderRadius: 999,
+                            bgcolor: customer.color,
+                          },
+                        }}
+                      />
+                    </Box>
+                  ))}
+                </Stack>
+              </Paper>
+            <Stack spacing={3} sx={{ minWidth: 0 }}>
+              <Paper
+                elevation={0}
+                sx={{
+                  borderRadius: 4,
+                  p: 3,
+                  boxShadow: "0 12px 30px rgba(0,0,0,0.05)",
+                  bgcolor: "#fff",
+                }}
+              >
+                <Typography variant="h6" fontWeight={700}>
+                  กิจกรรม
+                </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    สถานะการติดตามลูกค้าในสัปดาห์นี้
+                  </Typography>
+
+                  <Stack spacing={2.5} sx={{ mt: 3 }}>
+                    {activities.map((activity) => (
+                      <Box key={activity.label}>
+                        <Stack direction="row" justifyContent="space-between" alignItems="center">
+                          <Typography variant="subtitle2" fontWeight={600}>
+                            {activity.label}
+                          </Typography>
+                          <Typography variant="subtitle2" fontWeight={700}>
+                            {activity.value}%
+                          </Typography>
+                        </Stack>
+                        <LinearProgress
+                          variant="determinate"
+                          value={activity.value}
+                          sx={{
+                            mt: 1,
+                            height: 8,
+                            borderRadius: 999,
+                            bgcolor: "rgba(0,0,0,0.08)",
+                            "& .MuiLinearProgress-bar": {
+                              borderRadius: 999,
+                              bgcolor: activity.color,
+                            },
+                          }}
+                        />
+                      </Box>
+                    ))}
+                  </Stack>
+              </Paper>
+
+              <Paper
+                elevation={0}
+                sx={{
+                  borderRadius: 4,
+                  p: 3,
+                  boxShadow: "0 12px 30px rgba(0,0,0,0.05)",
+                  bgcolor: "#fff",
+                }}
+              >
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Typography variant="h6" fontWeight={700}>
+                    โปรโมชั่น
+                    </Typography>
+                    <WorkspacePremiumRoundedIcon color="warning" />
+                  </Stack>
+                  <Typography variant="body2" color="text.secondary">
+                    แคมเปญและสิทธิพิเศษประจำเดือนนี้
+                  </Typography>
+
+                  <Stack spacing={2.5} sx={{ mt: 3 }}>
+                    {promotions.map((promotion) => (
+                      <Box
+                        key={promotion.title}
+                        sx={{
+                          p: 2,
+                          borderRadius: 3,
+                          bgcolor: promotion.color,
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: 1,
+                        }}
+                      >
+                        <Typography variant="subtitle1" fontWeight={700}>
+                          {promotion.title}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {promotion.description}
+                        </Typography>
+                        <Chip
+                          label={promotion.chipLabel}
+                          color={promotion.chipColor}
+                          size="small"
+                          sx={{ alignSelf: "flex-start", borderRadius: 999, fontWeight: 600 }}
+                        />
+                      </Box>
+                    ))}
+                  </Stack>
+              </Paper>
+            </Stack>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource/prompt": "^5.2.8",
     "@fontsource/roboto": "^5.2.8",
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.0))(@types/react@19.1.13)(react@19.1.0)
+      '@fontsource/prompt':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@fontsource/roboto':
         specifier: ^5.2.8
         version: 5.2.8
@@ -351,6 +354,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource/prompt@5.2.8':
+    resolution: {integrity: sha512-/ocBE0NMMgfzKXcwTsKDJOppc3UA7dBGl127b9uhNzqUlP0720FCSuUXEp2iJb7uC/jnfHW1da7oZtAHDv3whg==}
 
   '@fontsource/roboto@5.2.8':
     resolution: {integrity: sha512-oh9g4Cg3loVMz9MWeKWfDI+ooxxG1aRVetkiKIb2ESS2rrryGecQ/y4pAj4z5A5ebyw450dYRi/c4k/I3UBhHA==}
@@ -1683,6 +1689,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.10':
     optional: true
+
+  '@fontsource/prompt@5.2.8': {}
 
   '@fontsource/roboto@5.2.8': {}
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,8 +1,21 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme } from "@mui/material/styles";
 
 const theme = createTheme({
   palette: {
-    primary: { main: '#1976d2' },
+    primary: { main: "#c62828" },
+    secondary: { main: "#ffb300" },
+    background: {
+      default: "#f4f6f8",
+      paper: "#ffffff",
+    },
+  },
+  shape: {
+    borderRadius: 16,
+  },
+  typography: {
+    fontFamily: '"Prompt", "Roboto", "Helvetica", "Arial", sans-serif',
+    fontWeightMedium: 600,
+    fontWeightBold: 700,
   },
 });
 


### PR DESCRIPTION
## Summary
- create a dashboard view that mirrors the provided CRM mock with sidebar, header, summary tiles, charts, and activity cards
- wire the dashboard page to the new layout while enforcing authenticated access
- switch to bundled Prompt font files and update the theme/login form styling for consistent typography

## Testing
- pnpm build *(fails: PrismaClient types are missing until Prisma generates client code)*

------
https://chatgpt.com/codex/tasks/task_e_68d4a59fc32c832397c535411db62cc2